### PR TITLE
Fix Tailwind PostCSS plugin and document TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # with-tailwindcss
 
-This is a minimal Next.js example using Tailwind CSS.
+This is a minimal Next.js example using Tailwind CSS and TypeScript.
+It requires the TypeScript tooling that ships with Next.js.
 
 ## Getting Started
 
@@ -8,3 +9,10 @@ This is a minimal Next.js example using Tailwind CSS.
 npm install
 npm run dev
 ```
+
+To create a production build locally:
+
+```bash
+npm run build
+```
+

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   "devDependencies": {
     "autoprefixer": "latest",
     "postcss": "latest",
-    "tailwindcss": "latest"
+    "tailwindcss": "latest",
+    "@tailwindcss/postcss": "latest",
+    "@types/node": "latest",
+    "@types/react": "latest",
+    "typescript": "latest"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- update README with TypeScript notes and build instructions
- ensure Tailwind PostCSS plugin is used alongside TypeScript tooling

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd4165be88329a59051f67e64c70b